### PR TITLE
Fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ To run locally:
 1. Create venv: `uv sync`
 2. Activate: `.venv\Scripts\activate`
 4. Copy .env to root dir
-3. Run app (change working dir path in Makefile): `make run-streamlit`
+5. Run app: `make run-streamlit`
+
 
 
 


### PR DESCRIPTION
Fixed README.md. Deleted instruction to change working dir, because it does not apply when running the app locally.